### PR TITLE
feat(node): do not override repository's .npmrc

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -63,14 +63,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup Registry
       run: |
-        echo "registry=${{ inputs.nexus-url }}" > .npmrc
-        echo -e "email=engineering@teckro.com" >> .npmrc
-        echo -e "legacy-peer-deps=true" >> .npmrc
+        npm config set registry "${{ inputs.nexus-url }}" -g
+        npm config set email "engineering@teckro.com" -g
+        npm config set legacy-peer-deps true -g
 
     - name: Install Dependencies
       id: install-dep
       run: |
-        cat .npmrc
+        npm config list
         npm cache verify
         npm ci
     


### PR DESCRIPTION
--PR for discussion--

.npmrc per repo is currently overridden. But a repository might use for example fontawesome pro and require additional config

Note: I am unsure as well that we really want the legacy-peer-deps set at all. imo it should be set per repo


on another note, using npm command line over modifying directly the .npmrc is a better approach I belive