### PR TITLE
feat(node): BLUE-3233 split lint from test

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -78,11 +78,15 @@ jobs:
       id: build
       run: npm run build
 
-    - name: Test and Lint
-      id: test-lint
+    - name: Lint
+      id: lint
+      run: |
+        npm run lint
+
+    - name: Test
+      id: test
       run: |
         npm run test:ci
-        npm run lint
 
     - name: SonarQube Scan
       id: scan


### PR DESCRIPTION
I want lint to be executed before the tests because test usually take more time and are longer to fix

I want to be able to tell if it's a lint issue or an error in a fraction of sec